### PR TITLE
Corrected Bugs

### DIFF
--- a/controllers/application_controller.php
+++ b/controllers/application_controller.php
@@ -81,7 +81,7 @@ function render_layout($template_name) {
 
   $template_content = ob_get_clean();
 
-  echo $template_content;
+  return $template_content;
 }
 
 /**

--- a/views/layouts/application.php
+++ b/views/layouts/application.php
@@ -15,8 +15,9 @@ $data = array(
   "files" => $_FILES,
 );
 
-if ($action === 'create' || $action === 'update' || $action === 'destroy') {
-  if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+if ($action === 'create' || $action === 'update' || $action === 'delete' || 
+      $action === 'purge_image' || $action === 'patch' || $action === 'destroy') {
+  if ($_SERVER['REQUEST_METHOD'] !== 'POST' && $_SERVER['REQUEST_METHOD'] !== 'GET') {
     redirect_to_error('405');
   }
 
@@ -56,11 +57,11 @@ if ($action === 'create' || $action === 'update' || $action === 'destroy') {
       <?= render($action, $controller, $data); ?>
     </div>
   <?php else: ?>
-    <?php render_layout('header'); ?>
+    <?= render_layout('header'); ?>
     
     <div class="container">
       <nav id="main-nav">
-        <?php render_layout('sidebar_main'); ?>
+        <?= render_layout('sidebar_main'); ?>
       </nav>
 
       <main>
@@ -75,7 +76,7 @@ if ($action === 'create' || $action === 'update' || $action === 'destroy') {
         <span class="close-modal" onclick="closeModal()">&times;</span>
       </div>
 
-      <?php render_layout('sidebar_chats'); ?>
+      <?= render_layout('sidebar_chats'); ?>
     </div>
   <?php endif; ?>
 </body>


### PR DESCRIPTION
## Description

- What changes are being made?
Corrected the error
```
[php:warn] [pid 4251] [client 127.0.0.1:53824] PHP Warning:  Cannot modify header information - headers already sent by (output started at application_controller.php:84) in posts_controller.php on line 189
```
- Why are these changes necessary?
The warning make the PHP unexpectedly stop, leading in the page not loading entirely 

## List of Changes

1. Change the function render_layout from echoed to return, which make return the input and let the render to application.php instead of render from application_controller and return the result to application which generate the error
2. Add more methods which generate actions to the if statement in application.php to avoid render unnecessary html  

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

