### PR TITLE
echo comment counter

### DIFF
--- a/controllers/posts_controller.php
+++ b/controllers/posts_controller.php
@@ -130,16 +130,21 @@ class PostsController extends Post {
                 exit;
             } else {
                 http_response_code(404);
-                echo json_encode(['error' => 'No comments found']);
-                exit;
+                $message = 'No comments found';
             }
         } catch (Exception $e) {
             http_response_code(500);
-            echo json_encode(['error' => 'Internal server error']);
-            exit;
+            $message = 'Internal server error';
         }
-
+    
+        if (isset($message) && $message === 'No comments found') {
+            $message = 'No comments available';
+        }
+    
+        echo json_encode(['error' => $message]);
+        exit;
     }
+    
 
     /**
      * Delete a post and redirect to the index view

--- a/db/posts/procedures.sql
+++ b/db/posts/procedures.sql
@@ -55,15 +55,17 @@ BEGIN
     posts.*,
     users.username,
     users.email,
-    COALESCE(COUNT(pr.post_id), 0) AS total_reactions
+    COALESCE(COUNT(DISTINCT pr.post_id), 0) AS total_reactions,
+    COALESCE(COUNT(DISTINCT c.id), 0) AS total_comments
   FROM posts
   INNER JOIN users ON posts.user_id = users.id
   LEFT JOIN post_reactions pr ON posts.id = pr.post_id
-  GROUP BY posts.id;
+  LEFT JOIN comments c ON posts.id = c.post_id
+  GROUP BY posts.id, users.username, users.email;
 END
 $$
-
 DELIMITER ;
+
 
 -- call as: CALL get_all_posts();
 
@@ -78,17 +80,18 @@ BEGIN
     posts.*,
     users.username AS username,
     users.email AS email,
-    COALESCE(COUNT(pr.post_id), 0) AS total_reactions
+    COALESCE(COUNT(DISTINCT pr.post_id), 0) AS total_reactions,
+    COALESCE(COUNT(DISTINCT c.id), 0) AS total_comments
   FROM posts
   INNER JOIN users ON posts.user_id = users.id
   LEFT JOIN post_reactions pr ON posts.id = pr.post_id
+  LEFT JOIN comments c ON posts.id = c.post_id
   WHERE posts.id = p_id
-  GROUP BY posts.id;
+  GROUP BY posts.id, users.username, users.email;
 END
 $$
 
 DELIMITER ;
-
 
 -- call as: CALL get_post_by_id(1);
 

--- a/public/resources/js/comments.js
+++ b/public/resources/js/comments.js
@@ -2,7 +2,6 @@ $(document).ready(function() {
     const $commentsContainer = $('#comments');
     let currentEditingCommentId = null;
 
-    // Función de inicialización
     function initComments() {
         $('.comments-view-less').hide();
         $('.child-comments').hide();
@@ -89,8 +88,14 @@ $(document).ready(function() {
             data: { postId: postId },
             success: function(response) {
                 const comments = JSON.parse(response);
-                $commentsContainer.html(generateCommentsHTML(comments));
-                initComments(); // Reiniciar la visibilidad de los botones y comentarios anidados
+                const commentsHTML = generateCommentsHTML(comments);
+                $commentsContainer.html(commentsHTML);
+                initComments();
+                const totalComments = comments.length;
+                $('.count_comments p').text(totalComments + ' Comments');
+            },
+            error: function() {
+                $commentsContainer.html('<p> Be the first to comment on this post! </p>');
             }
         });
     }

--- a/views/posts/index.php
+++ b/views/posts/index.php
@@ -38,8 +38,8 @@
                     </p>
 
                     <div class="info">
-                        <p>243K Visualization</p>
-                        <p>243k comments</p>
+                        <p> Visualization</p>
+                        <p><?= $d['total_comments'] ?? 0 ?> comments</p>
                     </div>
                 </div>
 

--- a/views/posts/show.php
+++ b/views/posts/show.php
@@ -62,7 +62,7 @@
 <div class="main_comments">
   <div class="count_comments">
     <i class='bx bxs-chat'></i>
-    <p>243k Comments</p>
+    <p> <?= $data['total_comments'] ?? 0 ?>  Comments</p>
     <button><i class='bx bx-dots-horizontal-rounded'></i></button>
   </div>
   <div class="line"></div>


### PR DESCRIPTION
**PR Title: #76 Echo Comments Counter - Implement Dynamic Comment Count Updates**
**Description**
This PR introduces functionality to dynamically update the comments counter when users add or delete comments. The following changes were made:

**Procedures Modified**

- get_comments_by_post_id: Updated to return the latest comment count.
- delete_comment_by_id: Modified to reflect the comment count change upon deletion.
- get_all_posts: Adjusted to include comment counts for each post.
- get_post_by_id: Enhanced to return the updated comment count for the specific post.

**JavaScript Changes**
comments.js: Added logic to update the comments counter dynamically when a comment is added or deleted.
**PHP Changes**

- index.php: Adjusted to display the correct initial comment count for each post.
- show.php: Enhanced to dynamically update the comment count when comments are added or deleted.